### PR TITLE
Fixed importing Terser failing the build..."

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,6 @@ import { rollupPluginHTML as html } from '@web/rollup-plugin-html';
 import css from "rollup-plugin-import-css";
 import { copy } from '@web/rollup-plugin-copy';
 import resolve from '@rollup/plugin-node-resolve';
-import { default as terser } from '@rollup/plugin-terser';
 import summary from 'rollup-plugin-summary';
 
 export default {


### PR DESCRIPTION
- added packae-lock to .gitignore
- Updated the server to serve our files better We should be able to serve any basic kind of file without problem
- Using modules to import functionnality Added a basic css to test if everything is working with Rollup
- Added rollup to bundle our app It was needed to allow using modern imports for Google MaterialUI Added google material UI so that I don't recreate a new CSS library...
- Modulized our header so that we can just import part of the app as modules
- Added a build command for Render live
- Added a build command for Render live
- Reworked build so that we use --node-resolve
- Reverted build script
- added new css extension regex to prevent console error
- Remove build folder from git history
- Wrong place for content-type...
- TryCatching to make sure we have no error
- Some more logging
- Returning before trying to display our error route
- Made sure to return out of our function so that no excessive logging is done
- removed a console.log
- More server sided logging
- better end-user address collecting
- Removed Terser from our dependencies I don't do anything meaningfull enough to minify my JS It's easier to read code directly from the Dev Console this way
- Created a quick footer component
- Some styling for our header Removed the material tabs since I don't plan to use it yet
- Started styling
- Some styling and added new components to our index file
- Created a hero_banner component
- Fixed wrong import
